### PR TITLE
Added -i option to read from stdin instead of a file

### DIFF
--- a/bin/markdown-html.js
+++ b/bin/markdown-html.js
@@ -27,7 +27,7 @@ var optimist =  require('optimist')
         'template': 'Path to custom mustache template',
         'help': 'This screen',
         'output-file': 'Path to output file (stdout if not specified)',
-        'i': 'If set, stdin will be used instead of file'
+        'stdin': 'If set, stdin will be used instead of file'
     })
     .default({
         'style': path.resolve(templateDir + '/style.css'),

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Pawel Maciejewski <fragphace@gmail.com> (http://fragphace.pl)",
   "name": "markdown-html",
   "description": "Command line tool for markdown to html conversion.",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "homepage": "https://github.com/fragphace/markdown-html",
   "repository": {
     "type": "git",


### PR DESCRIPTION
To use this tool in combination with others, I found it useful to have a option which allows to pipe markdown text into it, instead having to read it from a file.

Example Usage:

```
cat README.md | markdown-html -i
```

or

```
cat README.md | markdown-html --stdin
```
